### PR TITLE
Update the spec helper with the path to the test_app so rspec can run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /pkg/
 /spec/reports/
 /spec/test_app/db/test.sqlite3
+/spec/test_app/log/
 /tmp/
 
 ## Documentation cache and generated files:

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,6 +1,6 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV['RAILS_ENV'] ||= 'test'
-require File.expand_path('../../config/environment', __FILE__)
+require File.expand_path("../../spec/test_app/config/environment", __FILE__)
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'spec_helper'


### PR DESCRIPTION
When I tried to run rspec with actual tests, I hit an error:

![image](https://cloud.githubusercontent.com/assets/468136/10806085/ad9cadd4-7e37-11e5-9f96-1117bb75b56d.png)

Fortunately, Josh Coffee posted something helpful somewhere:

![image](https://cloud.githubusercontent.com/assets/468136/10806126/cd82127e-7e37-11e5-9b7d-c01ba257b34d.png)

Thanks, Josh Coffee!
