### PR TITLE
Rails generators for Guide

### DIFF
--- a/lib/generators/guide/component/USAGE
+++ b/lib/generators/guide/component/USAGE
@@ -1,0 +1,8 @@
+Description:
+    Generate new Guide component
+
+Example:
+    rails generate component component_name
+
+    This will create:
+        app/styleguide/guide/component_name.rb

--- a/lib/generators/guide/component/component_generator.rb
+++ b/lib/generators/guide/component/component_generator.rb
@@ -1,0 +1,13 @@
+class Guide::ComponentGenerator < Rails::Generators::NamedBase
+  source_root File.expand_path('../templates', __FILE__)
+
+  def generate_component
+    template "component.rb.erb", "app/styleguide/#{file_path}.rb"
+  end
+
+  private
+
+  def full_class_name
+    "Guide::Content::#{class_name}"
+  end
+end

--- a/lib/generators/guide/component/templates/component.rb.erb
+++ b/lib/generators/guide/component/templates/component.rb.erb
@@ -1,0 +1,15 @@
+class <%= full_class_name %> < Guide::Component
+  def template
+    # view partial name
+  end
+
+  def view_model
+    # Guide::ViewModel.new
+  end
+
+  private
+
+  # scenario :scenario_name do
+  #   view_model
+  # end
+end

--- a/lib/generators/guide/initializer/USAGE
+++ b/lib/generators/guide/initializer/USAGE
@@ -1,0 +1,8 @@
+Description:
+  Generate initializer for guide
+
+Example:
+    rails generate guide:initializer
+
+    This will create:
+        config/initializers/guide.rb

--- a/lib/generators/guide/initializer/initializer_generator.rb
+++ b/lib/generators/guide/initializer/initializer_generator.rb
@@ -1,0 +1,7 @@
+class Guide::InitializerGenerator < Rails::Generators::Base
+  source_root File.expand_path("../templates", __FILE__)
+
+  def copy_initializer_file
+    copy_file "initializer.rb", "config/initializers/guide.rb"
+  end
+end

--- a/lib/generators/guide/initializer/templates/initializer.rb
+++ b/lib/generators/guide/initializer/templates/initializer.rb
@@ -1,0 +1,12 @@
+Guide.configure do |config|
+  # config.company_name = 'Replace with your company name'
+  # config.controller_class_to_inherit = 'ApplicationController'
+end
+
+Guide::Tree.draw do
+  # node :structures do
+  #   node :purchase_flow do
+  #     component :checkout
+  #   end
+  # end
+end

--- a/lib/generators/guide/install/USAGE
+++ b/lib/generators/guide/install/USAGE
@@ -1,0 +1,5 @@
+Description:
+  Install Guide for your Rails app
+
+Example:
+    rails generate guide:install

--- a/lib/generators/guide/install/install_generator.rb
+++ b/lib/generators/guide/install/install_generator.rb
@@ -1,5 +1,6 @@
 class Guide::InstallGenerator < Rails::Generators::Base
   def invoke_generators
     generate "guide:initializer"
+    generate "guide:routes"
   end
 end

--- a/lib/generators/guide/install/install_generator.rb
+++ b/lib/generators/guide/install/install_generator.rb
@@ -1,0 +1,5 @@
+class Guide::InstallGenerator < Rails::Generators::Base
+  def invoke_generators
+    generate "guide:initializer"
+  end
+end

--- a/lib/generators/guide/routes/USAGE
+++ b/lib/generators/guide/routes/USAGE
@@ -1,0 +1,7 @@
+Description:
+    Mount Guide routes as Rails engine
+
+Example:
+    rails generate guide:routes
+
+    This will add routes to config/routes.rb

--- a/lib/generators/guide/routes/routes_generator.rb
+++ b/lib/generators/guide/routes/routes_generator.rb
@@ -1,0 +1,5 @@
+class Guide::RoutesGenerator < Rails::Generators::Base
+  def add_route
+    route %{mount Guide::Engine => "/guide"}
+  end
+end


### PR DESCRIPTION
This PR adds two generators for Guide.

`rails generate guide:install` will
- create sample initializer in `config/initializers/guide.rb`
- mount engine to `config/routes.rb`

`rails generate guide:component path_to/component_name` will
- create sample component file in `app/styleguide/path_to/component_name.rb`
