### PR TITLE
Allow applications to inject helpers if they refuse to live without them

### DIFF
--- a/app/helpers/guide/application_helper.rb
+++ b/app/helpers/guide/application_helper.rb
@@ -1,4 +1,4 @@
-module Guide
-  module ApplicationHelper
-  end
+module Guide::ApplicationHelper
+  module DefaultInclude; end
+  include Guide.configuration.helper_module_to_globally_include.constantize
 end

--- a/app/views/guide/common/_category.html.erb
+++ b/app/views/guide/common/_category.html.erb
@@ -1,7 +1,7 @@
 <div class="sg-controls__category">
   <h2>
     <% if view.on_homepage? %>
-      <%= Guide.configuration.company_name%> Guide
+      <%= Guide.configuration.company_name %> Guide
     <% else %>
       <%= view.active_node_name %>
     <% end %>

--- a/lib/guide/configuration.rb
+++ b/lib/guide/configuration.rb
@@ -1,23 +1,25 @@
 class Guide::Configuration
-  attr_accessor :company_name,
+  attr_accessor :authorisation_system_class,
+    :company_name,
     :controller_class_to_inherit,
-    :supported_locales,
-    :authorisation_system_class,
-    :local_variable_for_view_model,
-    :default_stylesheets_for_structures,
+    :default_javascripts_for_documents,
     :default_javascripts_for_structures,
     :default_stylesheets_for_documents,
-    :default_javascripts_for_documents
+    :default_stylesheets_for_structures,
+    :helper_module_to_globally_include,
+    :local_variable_for_view_model,
+    :supported_locales
 
   def initialize
+    @authorisation_system_class = 'Guide::AuthorisationSystem::Default'
     @company_name = 'Your Awesome Company'
     @controller_class_to_inherit = 'ApplicationController'
-    @supported_locales = { "English" => "en" }
-    @authorisation_system_class = 'Guide::AuthorisationSystem::Default'
-    @local_variable_for_view_model = :view
-    @default_stylesheets_for_structures = []
+    @default_javascripts_for_documents = []
     @default_javascripts_for_structures = []
     @default_stylesheets_for_documents = []
-    @default_javascripts_for_documents = []
+    @default_stylesheets_for_structures = []
+    @helper_module_to_globally_include = 'Guide::ApplicationHelper::DefaultInclude'
+    @local_variable_for_view_model = :view
+    @supported_locales = { "English" => "en" }
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe Guide::ApplicationHelper do
+  describe 'inclusion of an injected helper module' do
+    context 'DefaultInclude has been supplied via default guide configuration' do
+      it "pulls the method into Guide::ApplicatonHelper" do
+        expect(described_class.ancestors).to include(Guide::ApplicationHelper::DefaultInclude)
+      end
+    end
+  end
+end


### PR DESCRIPTION
View models are definitely the preferred way to push data to templates.

However, sometimes the host application will call a helper method in a template. Sometimes it's for a legitimate reason - perhaps the helper method does some html manipulation that would be inappropriate in the backend. Sometimes it's a symptom of legacy code. Either way, it would be kind of us to provide some basic support for it.

This change allows the host application to supply the name of a module as a configuration value. This module will be included into the `ApplicationHelper` of the Guide gem, making the corresponding helper methods available to templates.
