### PR TITLE
Let there be a single view model per document for image paths and such

### DIFF
--- a/app/models/guide/node.rb
+++ b/app/models/guide/node.rb
@@ -50,6 +50,10 @@ class Guide::Node
     false
   end
 
+  def view_model
+    Guide::ViewModel.new
+  end
+
   private
 
   def infer_id_from_class_name

--- a/app/view_models/guide/node_view.rb
+++ b/app/view_models/guide/node_view.rb
@@ -7,7 +7,8 @@ class Guide::NodeView
     :template,
     :layout_css_classes,
     :node_type,
-    :can_be_rendered?, :to => :@node
+    :can_be_rendered?,
+    :view_model, :to => :@node
 
   attr_reader :node_path
 

--- a/app/views/guide/nodes/_document.html.erb
+++ b/app/views/guide/nodes/_document.html.erb
@@ -1,3 +1,3 @@
 <div class="sg-prism">
-  <%= render view.template %>
+  <%= render view.template, :view => view.view_model %>
 </div>


### PR DESCRIPTION
I've put the `view_model` method on `Node` just so that if we call `Guide::NodeView#view_model`, it won't explode in a big mess if it's not a `Guide::Document`. I don't see a need for view models on non-documents at this stage but better safe than sorry!
