### PR TITLE
Don't raise a NotImplementedError if template isn't used; breaks cells.

### DIFF
--- a/app/models/guide/structure.rb
+++ b/app/models/guide/structure.rb
@@ -1,6 +1,6 @@
 class Guide::Structure < Guide::Node
   def template
-    partial || raise(NotImplementedError)
+    partial
   end
 
   def partial


### PR DESCRIPTION
This was breaking all of the structures in Envato Market that used Cells. 

Turns out when a structure documents a cell, we don't use the `template` method. This has led to me believe that raising a `NotImplementedError` is over-zealous and limits what the application can do with the gem.
