### PR TITLE
Allow all node types to make use of the private #image_path method

### DIFF
--- a/app/models/guide/node.rb
+++ b/app/models/guide/node.rb
@@ -54,6 +54,10 @@ class Guide::Node
     Guide::ViewModel.new
   end
 
+  def image_path(image_name, extension = "png")
+    Guide::Photographer.new(image_name, extension).image_path
+  end
+
   private
 
   def infer_id_from_class_name

--- a/app/models/guide/structure.rb
+++ b/app/models/guide/structure.rb
@@ -69,10 +69,6 @@ class Guide::Structure < Guide::Node
 
   private
 
-  def image_path(image_name, extension = "png")
-    Guide::Photographer.new(image_name, extension).image_path
-  end
-
   def default_layout_template
     Guide.configuration.default_layout_for_scenarios
   end


### PR DESCRIPTION
We want to be able to use this method in documents too, since sometimes we want images in our documents.

Let's generalise it to all node types.
