### PR TITLE
remove browserify.rb

### DIFF
--- a/app/models/guide/browserify.rb
+++ b/app/models/guide/browserify.rb
@@ -1,5 +1,0 @@
-module Guide::Browserify
-  def self.bundle_path
-    "guide/bundle.js"
-  end
-end


### PR DESCRIPTION
This pull request removes `app/models/guide/browserify.rb` as we're not using it anymore. Instead we are building the application.js and scenario.js directly into `app/assets/javascripts/` and sprocket will load it for us.
