### PR TITLE
add browser test setup and first test for layout view

### DIFF
--- a/javascript/tests/layout.test.js
+++ b/javascript/tests/layout.test.js
@@ -1,0 +1,30 @@
+var test = require('tape')
+var $ = require('jquery')
+
+var Layout = require('../views/layout')
+
+test('Layout View', function (t) {
+  $('body').append(`<div data-view="layout">
+    <div class="js-layout__nav-toggle"></div>
+    <div class="js-layout__nav-overlay"></div>
+  </div>`)
+
+  var el = $('body').find('[data-view]')[0]
+  var layoutView = new Layout($(el))
+
+  t.test('when click toggle div', function (assert) {
+    layoutView.dom.$toggle.trigger('click')
+    var expected = 'enabled'
+    var actual = $('body').attr('data-off-canvas')
+    assert.equal(expected, actual, 'should open nav')
+    assert.end()
+  })
+
+  t.test('when click overlay', function (assert) {
+    layoutView.dom.$overlay.trigger('click')
+    var expected = 'disabled'
+    var actual = $('body').attr('data-off-canvas')
+    assert.equal(expected, actual, 'should close nav')
+    assert.end()
+  })
+})

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "guide",
   "version": "1.0.0",
+  "private": "true",
   "description": "Document your application with a living component library and styleguide.",
   "scripts": {
     "build-application-js": "browserify javascript/application.js -o app/assets/javascripts/guide/application.js",
@@ -9,7 +10,8 @@
     "watch-application-js": "watchify -p browserify-hmr javascript/application.js -o app/assets/javascripts/guide/application.js",
     "watch-scenario-js": "watchify -p [ browserify-hmr -p 3124] javascript/scenario.js -o app/assets/javascripts/guide/scenario.js",
     "watch": "npm run watch-application-js & npm run watch-scenario-js",
-    "lint": "standard javascript/**/*.js | snazzy"
+    "lint": "standard javascript/**/*.js | snazzy",
+    "test": "npm run lint && browserify javascript/tests/*.test.js | tape-run"
   },
   "repository": {
     "type": "git",
@@ -34,6 +36,8 @@
     "browserify-hmr": "0.3.1",
     "snazzy": "^3.0.0",
     "standard": "^6.0.8",
+    "tape": "^4.5.1",
+    "tape-run": "^2.1.3",
     "watchify": "3.7.0"
   },
   "dependencies": {

--- a/scripts/buildkite_javascript.sh
+++ b/scripts/buildkite_javascript.sh
@@ -3,4 +3,4 @@
 set -ex
 
 npm install
-npm run lint
+npm test


### PR DESCRIPTION
This pull request adds the following:
- JavaScript browser test with tape-run, same settings as main marketplace repo, and it also the first step for use to test newly ported jQuery views function
- A real example of `layout.test.js` using the test setup
