### PR TITLE
Teaching Guide::ViewModel to keep track of the methods that we give it

### DIFF
--- a/app/models/guide/view_model.rb
+++ b/app/models/guide/view_model.rb
@@ -11,6 +11,8 @@ class Guide::ViewModel < OpenStruct
       )
     end
 
+    @guide_view_model_interface_methods = defaults.keys
+
     super(defaults.merge(overrides))
   end
 
@@ -23,6 +25,10 @@ class Guide::ViewModel < OpenStruct
         "but it does not exist on the #{self.class.name} in your Structure."
       )
     end
+  end
+
+  def guide_view_model_interface_methods
+    @guide_view_model_interface_methods
   end
 
   def to_ary

--- a/lib/guide/consistency_spec_helper.rb
+++ b/lib/guide/consistency_spec_helper.rb
@@ -18,37 +18,16 @@ module Guide::ConsistencySpecHelper
   private
 
   def expect_implemented_interface(object, interface)
-    expect(accessor_methods_defined_on(object)).
-      to include(*accessor_methods_defined_on(interface)),
+    expect(methods_defined_on(object)).
+      to include(*methods_defined_on(interface)),
       "I expected your #{object.class.name} to implement all of the methods on your #{interface.class.name}"
   end
 
-  def accessor_methods_defined_on(object)
-    if object.instance_of?(OpenStruct)
-      fail "[DEPRECATION] using OpenStruct is deprecated. Please use Guide::ViewModel instead."
-    elsif object.instance_of?(Guide::ViewModel) || object.class < Guide::ViewModel
-      methods_defined_on_view_model(object)
-    else
-      methods_defined_on(object)
-    end.sort
-  end
-
   def methods_defined_on(object)
-    object.methods - Module.instance_methods
-  end
-
-  def methods_defined_on_view_model(view_model)
-    methods_defined_on(view_model).
-      select  { |method| mutator?(method) }.
-      collect { |method| matching_accessor(method) }.
-      reject  { |method| method == :[] }
-  end
-
-  def mutator?(method)
-    method.to_s.end_with? '='
-  end
-
-  def matching_accessor(method)
-    method.to_s.gsub('=', '').to_sym
+    if object.kind_of?(Guide::ViewModel)
+      object.guide_view_model_interface_methods
+    else
+      object.methods - Module.instance_methods
+    end.sort
   end
 end

--- a/spec/models/guide/view_model_spec.rb
+++ b/spec/models/guide/view_model_spec.rb
@@ -18,4 +18,17 @@ RSpec.describe Guide::ViewModel do
         to raise_error(Guide::Errors::InterfaceViolation)
     end
   end
+
+  describe '#guide_view_model_interface_methods' do
+    let(:granted_methods) do
+      {
+        :granted_method => "expected reply for granted method",
+        :other_granted_method => "expected reply for other granted method"
+      }
+    end
+
+    it "returns a list of the methods that we given it" do
+      expect(view_model.guide_view_model_interface_methods).to eq [:granted_method, :other_granted_method]
+    end
+  end
 end


### PR DESCRIPTION
This change was motivated by the newer versions of OpenStruct not giving me a straight answer when asked `OpenStruct#methods`. Turns out it lazily defines the methods when you call them. Instead of dealing with that, Guide::ViewModel now keeps track of its interface. A lovely side effect is that the consistency spec helper is a lot cleaner!
