### PR TITLE
Add Markdown support

### DIFF
--- a/config/initializers/markdown.rb
+++ b/config/initializers/markdown.rb
@@ -1,0 +1,19 @@
+require 'rdiscount'
+
+module ActionView
+  module Template::Handlers
+    class Markdown
+      def self.call(template)
+        compiled_source = erb.call(template)
+        "RDiscount.new(begin;#{compiled_source};end).to_html.html_safe"
+      end
+
+      def self.erb
+        @erb ||= ActionView::Template.registered_template_handler(:erb)
+      end
+      private_class_method :erb
+    end
+  end
+end
+
+ActionView::Template.register_template_handler :md, ActionView::Template::Handlers::Markdown

--- a/guide.gemspec
+++ b/guide.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "LICENSE", "Rakefile", "README.rdoc"]
 
   s.add_dependency "rails", ">= 3.1", "< 5"
+  s.add_dependency "rdiscount"
   s.add_dependency "sass-rails", ">= 3.2"
 
   s.add_development_dependency "sqlite3"


### PR DESCRIPTION
To render markdown, use `.md` file extension.

Supports ERB parsing (don't append `.erb`).
