### PR TITLE
Fix render method deprecation warning

### DIFF
--- a/app/views/guide/scenarios/_scenario.html.erb
+++ b/app/views/guide/scenarios/_scenario.html.erb
@@ -5,14 +5,13 @@
         <%= cell(view.cell, view.view_model).call %>
       <% else %>
         <% if view.format == 'text' %>
-          <pre><%= render "#{view.template}.#{view.format}",
-                          Guide.configuration.local_variable_for_view_model => view.view_model %></pre>
-        <% elsif view.format == 'html' %>
-          <%= render  view.template,
-                      Guide.configuration.local_variable_for_view_model => view.view_model %>
+          <pre><%= render :partial => view.template,
+                          :locals => {Guide.configuration.local_variable_for_view_model => view.view_model},
+                          :formats => [view.format] %></pre>
         <% else %>
-          <%= render  "#{view.template}.#{view.format}",
-                      Guide.configuration.local_variable_for_view_model => view.view_model %>
+          <%= render  :partial => view.template,
+                      :locals => {Guide.configuration.local_variable_for_view_model => view.view_model},
+                      :formats => [view.format] %>
         <% end %>
       <% end %>
     </div>


### PR DESCRIPTION
```
DEPRECATION WARNING: Passing the format in the template name is
deprecated. Please pass render with :formats => [:text] instead.
```
