### PR TITLE
Revert "Fix render method deprecation warning"

### DIFF
--- a/app/views/guide/scenarios/_scenario.html.erb
+++ b/app/views/guide/scenarios/_scenario.html.erb
@@ -5,13 +5,14 @@
         <%= cell(view.cell, view.view_model).call %>
       <% else %>
         <% if view.format == 'text' %>
-          <pre><%= render :partial => view.template,
-                          :locals => {Guide.configuration.local_variable_for_view_model => view.view_model},
-                          :formats => [view.format] %></pre>
+          <pre><%= render "#{view.template}.#{view.format}",
+                          Guide.configuration.local_variable_for_view_model => view.view_model %></pre>
+        <% elsif view.format == 'html' %>
+          <%= render  view.template,
+                      Guide.configuration.local_variable_for_view_model => view.view_model %>
         <% else %>
-          <%= render  :partial => view.template,
-                      :locals => {Guide.configuration.local_variable_for_view_model => view.view_model},
-                      :formats => [view.format] %>
+          <%= render  "#{view.template}.#{view.format}",
+                      Guide.configuration.local_variable_for_view_model => view.view_model %>
         <% end %>
       <% end %>
     </div>


### PR DESCRIPTION
This reverts commit 0fa990144e8072274a74b485fc7aba9c3307e7b8.

When trying to render a "text" partial inside a HTML view rails loses the "text" format string somewhere deep in action_view.

Hopefully this is fixed by a newer version of Rails and we can reintroduce this fix.
