### PR TITLE
Only inject stylesheets for HTML scenarios

### DIFF
--- a/app/view_models/guide/scenario_layout_view.rb
+++ b/app/view_models/guide/scenario_layout_view.rb
@@ -27,8 +27,16 @@ class Guide::ScenarioLayoutView
     @format
   end
 
+  def inject_stylesheets?
+    @node.format == 'html'
+  end
+
   def node_stylesheets
     @node.stylesheets
+  end
+
+  def inject_javascripts?
+    @node.format == 'html'
   end
 
   def node_javascripts

--- a/app/views/layouts/guide/scenario.html.erb
+++ b/app/views/layouts/guide/scenario.html.erb
@@ -14,9 +14,11 @@
     <%= javascript_include_tag "guide/scenario" %>
     <%= stylesheet_link_tag("https://dmypbau5frl9g.cloudfront.net/assets/guide/scenario-0850d15390e6ad5383256d43d3473da2.css", :media => "all") %>
 
-    <% # Application specific stylesheets to render template %>
-    <% @layout_view.node_stylesheets.each do |styleheet|%>
-      <%= stylesheet_link_tag(styleheet, :media => "all") %>
+    <% # Application specific stylesheets with which to render the template %>
+    <% if @layout_view.inject_stylesheets? %>
+      <% @layout_view.node_stylesheets.each do |styleheet|%>
+        <%= stylesheet_link_tag(styleheet, :media => "all") %>
+      <% end %>
     <% end %>
   </head>
 
@@ -27,8 +29,10 @@
                   Guide.configuration.local_variable_for_view_model => @layout_view.node_layout_view
                 } %>
 
-    <% @layout_view.node_javascripts.each do |javascript|%>
-      <%= javascript_include_tag(javascript) %>
+    <% if @layout_view.inject_javascripts? %>
+      <% @layout_view.node_javascripts.each do |javascript|%>
+        <%= javascript_include_tag(javascript) %>
+      <% end %>
     <% end %>
   </body>
 </html>


### PR DESCRIPTION
We noticed recently on Envato Market that a text scenario had display issues when the corresponding HTML version had a node-specific stylesheet.

Node-specific stylesheets don't make sense for text scenarios, so let's limit them to HTML.

Edit: I've moved the decision-making logic up into the view model, plus extended this pattern to guard against including node-specific JavaScript on text-only templates.
