### PR TITLE
Enable Guide::EndpointStocktaker to map endpoints for non-html formats

### DIFF
--- a/app/models/guide/endpoint_stocktaker.rb
+++ b/app/models/guide/endpoint_stocktaker.rb
@@ -24,14 +24,16 @@ class Guide::EndpointStocktaker
   end
 
   def add_structure(node_path:, structure:)
-    structure.scenarios.keys.each do |scenario_id|
-      @result[endpoint_key(node_path, scenario_id: scenario_id)] = {
-        "path" => url_helpers.scenario_path(
-          :scenario_id => scenario_id,
-          :scenario_format => :html,
-          :node_path => node_path,
-        )
-      }
+    structure.formats.each do |format|
+      structure.scenarios.keys.each do |scenario_id|
+        @result[endpoint_key(node_path, scenario_id: scenario_id, scenario_format: format)] = {
+          "path" => url_helpers.scenario_path(
+            :scenario_id => scenario_id,
+            :scenario_format => format,
+            :node_path => node_path,
+          )
+        }
+      end
     end
   end
 
@@ -39,8 +41,12 @@ class Guide::EndpointStocktaker
     @result[endpoint_key(node_path)] = { "path" => url_helpers.node_path(node_path) }
   end
 
-  def endpoint_key(node_path, scenario_id: nil)
-    [formatted_node_path(node_path), formatted_scenario_id(scenario_id)].compact.join('-')
+  def endpoint_key(node_path, scenario_id: nil, scenario_format: nil)
+    [
+      formatted_node_path(node_path),
+      formatted_scenario_id(scenario_id),
+      scenario_format,
+    ].compact.join('-')
   end
 
   def formatted_node_path(node_path)

--- a/spec/models/guide/endpoint_stocktaker_spec.rb
+++ b/spec/models/guide/endpoint_stocktaker_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe Guide::EndpointStocktaker do
       "section" => "Section",
       "section/admin" => "Section » Admin",
       "section/friendly/example" => "Section » Friendly » Example",
+      "section/friendly/email" => "Section » Friendly » Email",
     }
   end
 
@@ -54,6 +55,7 @@ RSpec.describe Guide::EndpointStocktaker do
     allow(monkey).to receive(:fetch_node).with("section").and_return(section)
     allow(monkey).to receive(:fetch_node).with("section/admin").and_return(admin)
     allow(monkey).to receive(:fetch_node).with("section/friendly/example").and_return(example)
+    allow(monkey).to receive(:fetch_node).with("section/friendly/email").and_return(email)
   end
 
   let(:section) do
@@ -62,12 +64,20 @@ RSpec.describe Guide::EndpointStocktaker do
   let(:admin) do
     instance_double(Guide::Structure,
                     :node_type => :structure,
+                    :formats => [:html],
                     :scenarios => admin_scenarios)
   end
   let(:example) do
     instance_double(Guide::Structure,
                     :node_type => :structure,
+                    :formats => [:html],
                     :scenarios => example_scenarios)
+  end
+  let(:email) do
+    instance_double(Guide::Structure,
+                    :node_type => :structure,
+                    :formats => [:html, :text],
+                    :scenarios => email_scenarios)
   end
 
   let(:admin_scenarios) do
@@ -84,6 +94,12 @@ RSpec.describe Guide::EndpointStocktaker do
       :example_scenario_with_really_obnoxiously_long_name_probably_trying_to_describe_something_complicated => double,
     }
   end
+  let(:email_scenarios) do
+    {
+      :default => double,
+      :obscure_mail_client => double,
+    }
+  end
 
   describe '#to_hash' do
     subject(:to_hash) { stocktaker.to_hash }
@@ -93,25 +109,37 @@ RSpec.describe Guide::EndpointStocktaker do
         "section" => {
           "path" => "/guide/section"
         },
-        "section.admin-default" => {
+        "section.admin-default-html" => {
           "path" => "/guide/scenario/default/html/for/section/admin"
         },
-        "section.admin-special_case" => {
+        "section.admin-special_case-html" => {
           "path" => "/guide/scenario/special_case/html/for/section/admin"
         },
-        "section.friendly.example-signed_out" => {
+        "section.friendly.example-signed_out-html" => {
           "path" => "/guide/scenario/signed_out/html/for/section/friendly/example"
         },
-        "section.friendly.example-less_friendly" => {
+        "section.friendly.example-less_friendly-html" => {
           "path" => "/guide/scenario/less_friendly/html/for/section/friendly/example"
         },
-        "section.friendly.example-more_friendly" => {
+        "section.friendly.example-more_friendly-html" => {
           "path" => "/guide/scenario/more_friendly/html/for/section/friendly/example"
         },
-        "section.friendly.example-example_scenario_with_re..be_something_complicated" => {
+        "section.friendly.example-example_scenario_with_re..be_something_complicated-html" => {
           "path" => "/guide/scenario/example_scenario_with_really_obnoxiously_long_name_"\
-                    "probably_trying_to_describe_something_complicated/html/for/section/friendly/example"
-        }
+          "probably_trying_to_describe_something_complicated/html/for/section/friendly/example"
+        },
+        "section.friendly.email-default-html" => {
+          "path" => "/guide/scenario/default/html/for/section/friendly/email"
+        },
+        "section.friendly.email-obscure_mail_client-html" => {
+          "path" => "/guide/scenario/obscure_mail_client/html/for/section/friendly/email"
+        },
+        "section.friendly.email-default-text" => {
+          "path" => "/guide/scenario/default/text/for/section/friendly/email"
+        },
+        "section.friendly.email-obscure_mail_client-text" => {
+          "path" => "/guide/scenario/obscure_mail_client/text/for/section/friendly/email"
+        },
       }
     end
 


### PR DESCRIPTION
In Envato Market, we have been experimenting with visual regression testing. We currently use a tool called Wraith, which requires a config file containing a list of the endpoints that we want it to compare with a previous version.

To generate this config file, we use the `Guide::EndpointStocktaker`.

Structures can be rendered in multiple formats. This change makes the `Guide::EndpointStocktaker` generate an endpoint for each scenario, for each format, resulting in a more complete and accurate list. 
