### PR TITLE
Rails 4.2 performance fix

### DIFF
--- a/app/views/guide/_content.html.erb
+++ b/app/views/guide/_content.html.erb
@@ -2,7 +2,7 @@
   <div am-Grid class="h-text-align-center">
     <div am-Grid-Col="m:4 l:6" am-Grid-Row="m:start l:start">
       <div class="sg-home__section">
-        <%= link_to Guide::Engine.routes.url_helpers.node_path('structures'),
+        <%= link_to node_path('structures'),
                     :class => "t-link -color-dark -decoration-reversed" do %>
           <h3 class="t-heading -size-m">Structures</h3>
         <% end %>

--- a/app/views/guide/common/_navigation_node.html.erb
+++ b/app/views/guide/common/_navigation_node.html.erb
@@ -4,7 +4,7 @@
                     :class => top_level_node ? 'sg-navigation__section' : nil do %>
       <% if child_node_view.leaf_node? %>
         <%= link_to child_node_view.name,
-                    Guide::Engine.routes.url_helpers.node_path(
+                    node_path(
                       :node_path => if node_path.present?
                         "#{node_path}/#{child_node_view.id}"
                       else
@@ -15,7 +15,7 @@
       <% else %>
         <% if top_level_node %>
           <div class="sg-navigation__section-title">
-            <%= link_to Guide::Engine.routes.url_helpers.node_path(child_node_view.id) do %>
+            <%= link_to node_path(child_node_view.id) do %>
               <h4><%= child_node_view.name %></h4>
             <% end %>
           </div>

--- a/app/views/guide/common/_search.html.erb
+++ b/app/views/guide/common/_search.html.erb
@@ -9,7 +9,7 @@
             @layout_view.paths_to_visible_renderable_nodes.map do |node_path, node_title|
               {
                 :label => node_title,
-                :value => Guide::Engine.routes.url_helpers.node_path(
+                :value => node_path(
                   :node_path => node_path
                 )
               }

--- a/app/views/guide/nodes/_scenario.html.erb
+++ b/app/views/guide/nodes/_scenario.html.erb
@@ -9,7 +9,7 @@
                     nil,
                     :width => "100%",
                     :scrolling => "no",
-                    :src => Guide::Engine.routes.url_helpers.scenario_path(
+                    :src => scenario_path(
                       :scenario_id => scenario_id,
                       :node_path => node_path,
                       :scenario_format => scenario_format,

--- a/app/views/guide/scenarios/scenario/_toolbar.html.erb
+++ b/app/views/guide/scenarios/scenario/_toolbar.html.erb
@@ -26,7 +26,7 @@
           <%= link_to "L", "##{scenario_id}", :class => "js-guide__responsive-desktop t-link -color-inherit -decoration-reversed" %>
         </div>
         <div class="sg-actions__control">
-          <%= link_to Guide::Engine.routes.url_helpers.scenario_path(
+          <%= link_to scenario_path(
                         :scenario_id => scenario_id,
                         :node_path => view.node_path,
                         :scenario_format => view.formats.first,


### PR DESCRIPTION
There exists [a bug introduced in rails 4.2](https://github.com/rails/rails/pull/24554)
where calling the `url_helpers` of an engine will parse the entire set
of routes again and create a new object, as a result there is a huge
slowdown when looping, calling the `url_helpers` object again and again.

As the url helpers are included in the base controller, these methods
are available anyways, calling them this way doesn't parse all the
routes.

> Before: Completed 200 OK in 8337ms
> After: Completed 200 OK in 542ms
