### PR TITLE
Fix render deprecation warning

### DIFF
--- a/app/views/guide/scenarios/_scenario.html.erb
+++ b/app/views/guide/scenarios/_scenario.html.erb
@@ -4,16 +4,8 @@
       <% if view.uses_cells? %>
         <%= cell(view.cell, view.view_model).call %>
       <% else %>
-        <% if view.format == 'text' %>
-          <pre><%= render "#{view.template}.#{view.format}",
-                          Guide.configuration.local_variable_for_view_model => view.view_model %></pre>
-        <% elsif view.format == 'html' %>
-          <%= render  view.template,
-                      Guide.configuration.local_variable_for_view_model => view.view_model %>
-        <% else %>
-          <%= render  "#{view.template}.#{view.format}",
-                      Guide.configuration.local_variable_for_view_model => view.view_model %>
-        <% end %>
+        <pre><%= render partial: view.template, formats: [view.format], 
+          locals: { Guide.configuration.local_variable_for_view_model => view.view_model } %></pre>
       <% end %>
     </div>
   </div>


### PR DESCRIPTION
The warning looked like:

> DEPRECATION WARNING: Passing the format in the template name is
> deprecated. Please pass render with :formats => [:text] instead.
> (called from
> _vendor_bundle_ruby_______bundler_gems_guide____a_f__fff__app_views_guide_scenarios__scenario_html_erb___3737789344314660608_70136380035260
> at
> /var/lib/buildkite-agent/builds/market-ip-10-0-1-121.ec2.internal/envato-marketplaces/marketplace/vendor/bundle/ruby/2.2.0/bundler/gems/guide-328a2f35fff1/app/views/guide/scenarios/_scenario.html.erb:8)

It is now fixed by passing the correct args to the `render` method :)
