### PR TITLE
Updated controller to render 404 on partial node path

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source 'https://rubygems.org'
 
+gem 'rails-controller-testing'
+
 gemspec

--- a/app/controllers/guide/scenarios_controller.rb
+++ b/app/controllers/guide/scenarios_controller.rb
@@ -4,6 +4,9 @@ class Guide::ScenariosController < Guide::BaseController
   def show
     expose_layout
     expose_scenario
+  rescue NoMethodError => e
+    logger.warn { "Rendering 404 after rescuing: #{e}" }
+    render plain: 'Nothing to see here.', status: '404'
   end
 
   private

--- a/lib/guide/version.rb
+++ b/lib/guide/version.rb
@@ -1,3 +1,3 @@
 module Guide
-  VERSION = "0.4.0"
+  VERSION = "0.4.1"
 end

--- a/spec/controllers/guide/scenarios_controller_spec.rb
+++ b/spec/controllers/guide/scenarios_controller_spec.rb
@@ -104,6 +104,26 @@ RSpec.describe Guide::ScenariosController, :type => :controller do
       end
     end
 
+    context "the node_path is partial" do
+      let(:show) do
+        get(:show,
+            :node_path => partial_node_path,
+            :scenario_id => scenario_id.to_s,
+            :scenario_format => 'html')
+      end
+      let(:partial_node_path) { 'structures/friendly' }
+
+      context "we are not in a development environment" do
+        include_context description do
+          before { show }
+
+          it "renders a 404 not found response" do
+            expect(response).to have_http_status(:not_found)
+          end
+        end
+      end
+    end
+
     context "the node_path doesn't point to a valid node" do
       let(:show) do
         get(:show,


### PR DESCRIPTION
If a partial path is visited, that currently triggers a `NoMethod` error and returns a 500 

A valid url is: https://market.styleguide.envato.com/scenario/with_hosted_promo/html/for/structures/user/downloads/download is a valid url. 

A partial path that fails is: https://market.styleguide.envato.com/scenario/with_hosted_promo/html/for/structures/user/downloads

The partial path should return a 404 instead of a 500 error.

This change updates the scenario to catch this error and render a 404.  It also bumps the gem version.
