### PR TITLE
Upgrade the Buildkite pipeline to use Docker

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,38 @@
+---
+
+steps:
+  - label: ":javascript:"
+    command: ".buildkite/steps/javascript.sh"
+    plugins:
+      docker#v1.4.0:
+        image: "node:10-slim"
+    agents:
+      queue: "$AGENT_QUEUE"
+    timeout_in_minutes: 10
+
+  - label: ":ruby: 2.5 :rspec:"
+    command: ".buildkite/steps/rspec.sh"
+    plugins:
+      docker#v1.4.0:
+        image: "ruby:2.5"
+    agents:
+      queue: "$AGENT_QUEUE"
+    timeout_in_minutes: 10
+
+  - label: ":ruby: 2.4 :rspec:"
+    command: ".buildkite/steps/rspec.sh"
+    plugins:
+      docker#v1.4.0:
+        image: "ruby:2.4"
+    agents:
+      queue: "$AGENT_QUEUE"
+    timeout_in_minutes: 10
+
+  - label: ":ruby: 2.3 :rspec:"
+    command: ".buildkite/steps/rspec.sh"
+    plugins:
+      docker#v1.4.0:
+        image: "ruby:2.3"
+    agents:
+      queue: "$AGENT_QUEUE"
+    timeout_in_minutes: 10

--- a/.buildkite/steps/javascript.sh
+++ b/.buildkite/steps/javascript.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "--- Installing xvfb"
+apt-get update -y
+apt-get install -y libgtk2.0-0 libgconf-2-4 libasound2 libxtst6 libxss1 libnss3 xvfb
+
+echo "--- :npm: Installing"
+npm install
+
+echo "+++ :npm: Testing"
+Xvfb -ac -screen scrn 1280x2000x24 :10 &
+export DISPLAY=:10
+npm test

--- a/.buildkite/steps/rspec.sh
+++ b/.buildkite/steps/rspec.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "--- :bundler: Bundling"
+bundle install
+bundle exec appraisal install
+
+echo "+++ :rspec: Running RSpec"
+bundle exec appraisal rspec spec

--- a/scripts/buildkite_build.sh
+++ b/scripts/buildkite_build.sh
@@ -1,7 +1,0 @@
-#! /bin/bash
-
-set -ex
-
-bundle install --path vendor/bundle --retry 3
-bundle exec appraisal install
-bundle exec appraisal rspec spec

--- a/scripts/buildkite_javascript.sh
+++ b/scripts/buildkite_javascript.sh
@@ -1,6 +1,0 @@
-#! /bin/bash
-
-set -ex
-
-npm install
-npm test


### PR DESCRIPTION
We've been running this build on a legacy Buildkite queue. Soon we'll be getting rid of it. To start using our new queues, we'll need to start using Docker.

In this PR I've committed the pipeline configuration, and configured it to run the test steps in Docker. The Buildkite agent queue used to run the build steps is configurable via an environment setting (`$AGENT_QUEUE`). We can set this via the Buildkite web UI and is currently set it to our platform queue.

![image](https://user-images.githubusercontent.com/497874/45272905-44da2600-b4f3-11e8-98f1-9a433095341b.png)
