### PR TITLE
Remove upper Rails dependency limit

### DIFF
--- a/guide.gemspec
+++ b/guide.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "LICENSE", "Rakefile", "README.rdoc"]
 
-  s.add_dependency "rails", ">= 4", "< 6"
+  s.add_dependency "rails", ">= 4"
   s.add_dependency "sass-rails", ">= 3.2"
 
   s.add_development_dependency "appraisal"


### PR DESCRIPTION
This isn't needed and prevents us from using bleeding edge Rails.