### PR TITLE
Fix: scenario pages aren't rendering on Rails 6

### DIFF
--- a/app/controllers/guide/scenarios_controller.rb
+++ b/app/controllers/guide/scenarios_controller.rb
@@ -39,6 +39,6 @@ class Guide::ScenariosController < Guide::BaseController
   end
 
   def scenario_format
-    params[:scenario_format]
+    params[:scenario_format].to_sym
   end
 end

--- a/spec/controllers/guide/scenarios_controller_spec.rb
+++ b/spec/controllers/guide/scenarios_controller_spec.rb
@@ -36,6 +36,14 @@ RSpec.describe Guide::ScenariosController, :type => :controller do
                 expect(assigns(:scenario_view)).
                   to be_a Guide::ScenarioView
               end
+
+              context "rendering turned on" do
+                render_views
+
+                it "responds with 200 ok" do
+                  expect(response).to have_http_status(:ok)
+                end
+              end
             end
           end
 


### PR DESCRIPTION
### Context

On Rails 6, scenario pages fail with:

```
ActionView::Template::Error:
  Invalid formats: "html"
```

It seems Rails 6 requires the format to be in the form of a symbol (`:html`).

### Change

Convert the format to a symbol.