### PR TITLE
Restrict to latest supported versions of Ruby and Rails

### DIFF
--- a/guide.gemspec
+++ b/guide.gemspec
@@ -14,10 +14,10 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "LICENSE", "Rakefile", "README.rdoc"]
 
-  s.add_dependency "railties", ">= 4"
-  s.add_dependency "actionpack", ">= 4"
-  s.add_dependency "actionview", ">= 4"
-  s.add_dependency "activemodel", ">= 4"
+  s.add_dependency "railties", ">= 5.2"
+  s.add_dependency "actionpack", ">= 5.2"
+  s.add_dependency "actionview", ">= 5.2"
+  s.add_dependency "activemodel", ">= 5.2"
   s.add_dependency "sprockets-rails"
   s.add_dependency "sass-rails", ">= 3.2"
 

--- a/guide.gemspec
+++ b/guide.gemspec
@@ -15,6 +15,8 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "LICENSE", "Rakefile", "README.rdoc"]
 
   s.add_dependency "railties", ">= 4"
+  s.add_dependency "actionpack", ">= 4"
+  s.add_dependency "actionview", ">= 4"
   s.add_dependency "activemodel", ">= 4"
   s.add_dependency "sprockets-rails"
   s.add_dependency "sass-rails", ">= 3.2"

--- a/guide.gemspec
+++ b/guide.gemspec
@@ -14,6 +14,8 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "LICENSE", "Rakefile", "README.rdoc"]
 
+  s.required_ruby_version = ">= 2.6"
+
   s.add_dependency "railties", ">= 5.2"
   s.add_dependency "actionpack", ">= 5.2"
   s.add_dependency "actionview", ">= 5.2"


### PR DESCRIPTION
### Context

The oldest supported version of Ruby is 2.6.

The oldest supported version of Rails is 5.2.

The `guide` CI test suite doesn't test anything older: we have no guarantee that this gem will continue to work on older version of Ruby and Rails.

### Change

Limit the use of this gem to running with Ruby 2.6+ and Rails 5.2+.