### PR TITLE
Fix: links account for engine mount point

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,8 +168,8 @@ The homepage of your Guide is a special snowflake. Edit the contents here:
 In order to link to other Guide pages from within your content, you will need to use the `node_path` url helper. Here are a couple of examples:
 
 ```Ruby
-<%= link_to "root level link", Guide::Engine.routes.url_helpers.node_path('documents') %>
-<%= link_to "nested link", Guide::Engine.routes.url_helpers.node_path('documents/restricted') %>
+<%= link_to "root level link", guide.node_path('documents') %>
+<%= link_to "nested link", guide.node_path('documents/restricted') %>
 ```
 
 ### Fixtures

--- a/app/views/guide/_content.html.erb
+++ b/app/views/guide/_content.html.erb
@@ -2,7 +2,7 @@
   <div am-Grid class="h-text-align-center">
     <div am-Grid-Col="m:4 l:6" am-Grid-Row="m:start l:start">
       <div class="sg-home__section">
-        <%= link_to '/structures',
+        <%= link_to guide.node_path('structures'),
                     :class => "t-link -color-dark -decoration-reversed" do %>
           <h3 class="t-heading -size-m">Structures</h3>
         <% end %>

--- a/app/views/guide/common/_navigation_node.html.erb
+++ b/app/views/guide/common/_navigation_node.html.erb
@@ -4,12 +4,12 @@
                     :class => top_level_node ? 'sg-navigation__section' : nil do %>
       <% if child_node_view.leaf_node? %>
         <%= link_to child_node_view.name,
-                    node_path.present? ? "/#{node_path}/#{child_node_view.id}" : "/#{child_node_view.id}",
+                    guide.node_path([node_path, child_node_view.id].compact.join('/')),
                     :class => child_node_view.active? ? 'is-active' : nil %>
       <% else %>
         <% if top_level_node %>
           <div class="sg-navigation__section-title">
-            <%= link_to "/#{child_node_view.id}" do %>
+            <%= link_to(guide.node_path(child_node_view.id)) do %>
               <h4><%= child_node_view.name %></h4>
             <% end %>
           </div>

--- a/app/views/guide/nodes/_scenario.html.erb
+++ b/app/views/guide/nodes/_scenario.html.erb
@@ -9,6 +9,6 @@
                     nil,
                     :width => "100%",
                     :scrolling => "no",
-                    :src => "/scenario/#{scenario_id}/#{scenario_format}/for/#{node_path}"
+                    :src => guide.scenario_path(scenario_id, scenario_format, node_path)
                   ) %>
 <% end %>

--- a/app/views/guide/scenarios/scenario/_toolbar.html.erb
+++ b/app/views/guide/scenarios/scenario/_toolbar.html.erb
@@ -26,7 +26,7 @@
           <%= link_to "L", "##{scenario_id}", :class => "js-guide__responsive-desktop t-link -color-inherit -decoration-reversed" %>
         </div>
         <div class="sg-actions__control">
-          <%= link_to "/scenario/#{scenario_id}/#{view.formats.first}/for/#{view.node_path}",
+          <%= link_to guide.scenario_path(scenario_id, view.formats.first, view.node_path),
                       :class =>"sg-actions__icon",
                       :target => "_blank",
                       :alt => "Open this scenario in a new tab" do %>

--- a/spec/test_apps/shared/app/documentation/guide/_content.html.erb
+++ b/spec/test_apps/shared/app/documentation/guide/_content.html.erb
@@ -4,13 +4,13 @@
 <div class="h-my4">
   <h3 class="t-heading -size-m">Example links</h3>
   <ul class="t-list">
-    <li class="t-body h-m0"><%= link_to "Structures", Guide::Engine.routes.url_helpers.node_path('structures') %></li>
+    <li class="t-body h-m0"><%= link_to "Structures", guide.node_path('structures') %></li>
     <li class="t-body h-m0">
-      <%= link_to "Documents", Guide::Engine.routes.url_helpers.node_path('documents') %>
+      <%= link_to "Documents", guide.node_path('documents') %>
       <ul class="t-list">
-        <li class="t-body h-m0"><%= link_to "Public access example", Guide::Engine.routes.url_helpers.node_path('documents/public') %></li>
-        <li class="t-body h-m0"><%= link_to "Unpublished access example", Guide::Engine.routes.url_helpers.node_path('documents/unpublished') %></li>
-        <li class="t-body"><%= link_to "Restricted access example", Guide::Engine.routes.url_helpers.node_path('documents/restricted') %></li>
+        <li class="t-body h-m0"><%= link_to "Public access example", guide.node_path('documents/public') %></li>
+        <li class="t-body h-m0"><%= link_to "Unpublished access example", guide.node_path('documents/unpublished') %></li>
+        <li class="t-body"><%= link_to "Restricted access example", guide.node_path('documents/restricted') %></li>
       </ul>
     </li>
   </ul>

--- a/spec/views/guide/_content_spec.rb
+++ b/spec/views/guide/_content_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe 'guide/_content', type: :view do
+  it 'links to the structures node' do
+    render
+    expect(rendered).to match(%r{<a class="[^"]+" href="/guide/structures">})
+  end
+end

--- a/spec/views/guide/common/_navigation_node_spec.rb
+++ b/spec/views/guide/common/_navigation_node_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe 'guide/common/_navigation_node', type: :view  do
+  subject(:render_navigation_node) do
+    render(
+      partial: 'guide/common/navigation_node',
+      locals: {
+        view: navigation_view,
+        top_level_node: true,
+        node_path: node_path,
+      }
+    )
+  end
+
+  let(:navigation_view) { spy(Guide::NavigationView, child_node_views: [child_navigation_view]) }
+  let(:child_navigation_view) { spy(Guide::NavigationView, id: 'child-id', active?: child_active) }
+
+  context 'given an inactive child, without node_path' do
+    let(:child_active) { false }
+    let(:node_path) { nil }
+
+    it 'links to the child' do
+      render_navigation_node
+
+      expect(rendered).to include('<a href="/guide/child-id">')
+    end
+  end
+
+  context 'given an inactive child, without node_path' do
+    let(:child_active) { false }
+    let(:node_path) { 'node-path' }
+
+    it 'links to the child via the path' do
+      render_navigation_node
+
+      expect(rendered).to include('<a href="/guide/node-path/child-id">')
+    end
+  end
+
+  context 'given an active child' do
+    let(:child_active) { true }
+    let(:node_path) { nil }
+
+    it 'links to the child with active class' do
+      render_navigation_node
+
+      expect(rendered).to include('<a class="is-active" href="/guide/child-id">')
+    end
+  end
+end

--- a/spec/views/guide/nodes/_scenario_spec.rb
+++ b/spec/views/guide/nodes/_scenario_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe 'guide/nodes/_scenario', type: :view  do
+  subject(:render_scenario) do
+    render(
+      partial: 'guide/nodes/scenario',
+      locals: {
+        scenario_id: :scenario_id,
+        node_path: :node_path,
+        scenario_format: :scenario_format,
+      }
+    )
+  end
+
+  it 'renders scenario in an iframe' do
+    render_scenario
+    expect(rendered).to include('<iframe width="100%" scrolling="no" src="/guide/scenario/scenario_id/scenario_format/for/node_path">')
+  end
+end

--- a/spec/views/guide/scenarios/scenario/_toolbar_spec.rb
+++ b/spec/views/guide/scenarios/scenario/_toolbar_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe 'guide/scenarios/scenario/_toolbar', type: :view  do
+  subject(:render_toolbar) do
+    render(
+      partial: 'guide/scenarios/scenario/toolbar',
+      locals: {
+        view: node_view,
+        scenario: scenario,
+        scenario_id: :scenario_id,
+      }
+    )
+  end
+
+  let(:node_view) { spy(Guide::NodeView, formats: [:html], node_path: :node_path) }
+  let(:scenario) { spy(name: 'Default', view_model: nil, options: OpenStruct.new) }
+
+  it 'renders link to open scenario in new tab' do
+    render_toolbar
+    expect(rendered).to match(%r{<a class="[^"]+" target="_blank" alt="[^"]+" href="/guide/scenario/scenario_id/html/for/node_path">})
+  end
+end


### PR DESCRIPTION
### Context

`guide` is a Rails engine. Downstream users can chose to mount it at any point in their site, from the root `/`, to a deeply nested location `/some/nested/point`. Unfortunately, the links rendered on `guide` pages are all hardcoded to the root and navigation breaks if `guide` is not mounted at the root.

### Change

Rather than hardcoding links, make use of the Rails provided helpers. These accomodate where the engine has been mounted and correctly render the link href.

