### PR TITLE
Release version 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 - Add `actionpack` and `actionview` as explicit dependencies ([#94]).
   Previously, these were transitive dependencies.
+- Record project metadata in the gem spec ([#96]).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ## [Unreleased]
 
+[Unreleased]: https://github.com/envato/guide/compare/v0.6.0...HEAD
+
+## [0.6.0] - 2021-06-09
+
 ### Added
 
 - Add `actionpack` and `actionview` as explicit dependencies ([#94]).
@@ -35,7 +39,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 - Fixed links not using engine mount point ([#95]).
 - The `README.md` file is included in the gem ([#96]).
 
-[Unreleased]: https://github.com/envato/guide/compare/v0.5.0...HEAD
+[0.6.0]: https://github.com/envato/guide/compare/v0.5.0...v0.6.0
 [#91]: https://github.com/envato/guide/pull/91
 [#92]: https://github.com/envato/guide/pull/92
 [#93]: https://github.com/envato/guide/pull/93

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 - Fixed scenarios not rendering with Rails 6 ([#93]).
 - Fixed links not using engine mount point ([#95]).
+- The `README.md` file is included in the gem ([#96]).
 
 [Unreleased]: https://github.com/envato/guide/compare/v0.5.0...HEAD
 [#91]: https://github.com/envato/guide/pull/91
@@ -39,6 +40,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 [#93]: https://github.com/envato/guide/pull/93
 [#94]: https://github.com/envato/guide/pull/94
 [#95]: https://github.com/envato/guide/pull/95
+[#96]: https://github.com/envato/guide/pull/96
 
 ## [0.5.0] - 2021-03-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,99 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog], and this project adheres to
+[Semantic Versioning].
+
+[Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
+[Semantic Versioning]: https://semver.org/spec/v2.0.0.html
+
+## [Unreleased]
+
+### Added
+
+- Add `actionpack` and `actionview` as explicit dependencies ([#94]).
+  Previously, these were transitive dependencies.
+
+### Changed
+
+- CI build moved to run on GitHub Actions ([#91]).
+- CI test suite runs against the latest versions of Nodejs, Ruby, and Rails
+  ([#92]).
+
+### Removed
+
+- Removed support for Ruby 2.5 and lower ([#94]). Ruby 2.6 and higher is
+  required.
+- Removed support for Rails 5.1 and lower ([#94]). Rails 5.2 and higher is
+  required.
+
+### Fixed
+
+- Fixed scenarios not rendering with Rails 6 ([#93]).
+- Fixed links not using engine mount point ([#95]).
+
+[Unreleased]: https://github.com/envato/guide/compare/v0.5.0...HEAD
+[#91]: https://github.com/envato/guide/pull/91
+[#92]: https://github.com/envato/guide/pull/92
+[#93]: https://github.com/envato/guide/pull/93
+[#94]: https://github.com/envato/guide/pull/94
+[#95]: https://github.com/envato/guide/pull/95
+
+## [0.5.0] - 2021-03-25
+
+### Added
+
+- Move Buildkite CI configuration to code ([#86]).
+- Relaxed `rails` dependency constraints ([#87]). Allow using version 6 or
+  greater.
+
+### Changed
+
+- Replace `rails` dependency with dependency on `railties`, `activemodel`, and
+  `sprockets-rails` ([#89]).
+
+[0.5.0]: https://github.com/envato/guide/compare/v0.4.1...v0.5.0
+[#86]: https://github.com/envato/guide/pull/86
+[#87]: https://github.com/envato/guide/pull/87
+[#89]: https://github.com/envato/guide/pull/89
+
+## [0.4.1] - 2018-08-09
+
+### Changed
+
+- Replace `render text: 'plain text'` with `render plain: 'plain text'`
+  ([#85]).
+
+[0.4.1]: https://github.com/envato/guide/compare/v0.4.0...v0.4.1
+[#85]: https://github.com/envato/guide/pull/85
+
+## [0.4.0] - 2017-12-14
+
+### Added
+
+- Support for Rails 5 ([#82], [#83]):
+  - Relax the dependency constraints to allow `rails` 5.x
+  - Update the test suite to run against `rails` 4.2 and 5.1
+
+[0.4.0]: https://github.com/envato/guide/compare/v0.3.2...v0.4.0
+[#82]: https://github.com/envato/guide/pull/82
+[#83]: https://github.com/envato/guide/pull/83
+
+## [0.3.2] - 2017-03-26
+
+### Removed
+
+- Removed explicit support for Markdown ([#81]). Downstream applications can
+  implement this if desired.
+
+[0.3.2]: https://github.com/envato/guide/compare/v0.3.1...v0.3.2
+[#81]: https://github.com/envato/guide/pull/81
+
+## [0.3.1] - 2017-02-23
+
+### Added
+
+- First public release!
+
+[0.3.1]: https://github.com/envato/guide/releases/tag/v0.3.1

--- a/guide.gemspec
+++ b/guide.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.description = "Document your Rails application with a living component library and styleguide"
   s.license     = "MIT"
 
-  s.files = Dir["{app,config,db,lib}/**/*", "LICENSE", "Rakefile", "README.rdoc"]
+  s.files = Dir["{app,config,db,lib}/**/*", "LICENSE", "Rakefile", "README.md"]
 
   s.required_ruby_version = ">= 2.6"
 

--- a/guide.gemspec
+++ b/guide.gemspec
@@ -12,6 +12,13 @@ Gem::Specification.new do |s|
   s.description = "Document your Rails application with a living component library and styleguide"
   s.license     = "MIT"
 
+  s.metadata["homepage_uri"] = s.homepage
+  s.metadata["source_code_uri"] = "#{s.homepage}/tree/v#{s.version}"
+  s.metadata["changelog_uri"] = "#{s.homepage}/blob/HEAD/CHANGELOG.md"
+  s.metadata["bug_tracker_uri"] = "#{s.homepage}/issues"
+  s.metadata["wiki_uri"] = "#{s.homepage}/wiki"
+  s.metadata["documentation_uri"] = "https://www.rubydoc.info/gems/#{s.name}/#{s.version}"
+
   s.files = Dir["{app,config,db,lib}/**/*", "LICENSE", "Rakefile", "README.md"]
 
   s.required_ruby_version = ">= 2.6"

--- a/lib/guide/version.rb
+++ b/lib/guide/version.rb
@@ -1,3 +1,3 @@
 module Guide
-  VERSION = "0.5.0"
+  VERSION = "0.6.0"
 end


### PR DESCRIPTION
### Changes

- Bump version from 0.5.0 to 0.6.0
- Record changes in a CHANGELOG document
- Record project metadata in gem spec and on https://rubygems.org/gems/guide
- Include `README.md` in the gem.