### PR TITLE
Fix: include custom JS and CSS in HTML scenarios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,15 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ## [Unreleased]
 
+[Unreleased]: https://github.com/envato/guide/compare/v0.6.1...HEAD
+
+## [0.6.1] - 2021-06-10
+
 ### Fixed
 
 - Custom javascript and CSS is included in HTML scenarios ([#97]).
 
-[Unreleased]: https://github.com/envato/guide/compare/v0.6.0...HEAD
+[0.6.1]: https://github.com/envato/guide/compare/v0.6.0...v0.6.1
 [#97]: https://github.com/envato/guide/pull/97
 
 ## [0.6.0] - 2021-06-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,12 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Custom javascript and CSS is included in HTML scenarios ([#97]).
+
 [Unreleased]: https://github.com/envato/guide/compare/v0.6.0...HEAD
+[#97]: https://github.com/envato/guide/pull/97
 
 ## [0.6.0] - 2021-06-09
 
@@ -35,7 +40,25 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ### Fixed
 
-- Fixed scenarios not rendering with Rails 6 ([#93]).
+- Fixed scenarios not rendering with Rails 6 ([#93]). Please ensure formats are
+  specified using symbols when defining structures:
+
+  ```diff
+   def formats
+  -  ['html', 'text']
+  +  [:html, :text]
+   end
+
+   def layout_templates
+     {
+  -    'html' => 'layouts/my_html_layout',
+  -    'text' => 'layouts/my_text_layout'
+  +    html: 'layouts/my_html_layout',
+  +    text: 'layouts/my_text_layout'
+     }
+   end
+  ```
+
 - Fixed links not using engine mount point ([#95]).
 - The `README.md` file is included in the gem ([#96]).
 

--- a/app/view_models/guide/scenario_layout_view.rb
+++ b/app/view_models/guide/scenario_layout_view.rb
@@ -28,7 +28,7 @@ class Guide::ScenarioLayoutView
   end
 
   def inject_stylesheets?
-    @format == 'html'
+    @format == :html
   end
 
   def node_stylesheets
@@ -36,7 +36,7 @@ class Guide::ScenarioLayoutView
   end
 
   def inject_javascripts?
-    @format == 'html'
+    @format == :html
   end
 
   def node_javascripts

--- a/lib/guide/version.rb
+++ b/lib/guide/version.rb
@@ -1,3 +1,3 @@
 module Guide
-  VERSION = "0.6.0"
+  VERSION = "0.6.1"
 end

--- a/spec/view_models/guide/scenario_layout_view_spec.rb
+++ b/spec/view_models/guide/scenario_layout_view_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Guide::ScenarioLayoutView do
                     :javascripts => ['Node JavaScripts'])
   end
   let(:node_layout_templates) do
-    { 'html' => 'html/layout/template' }
+    { html: 'html/layout/template' }
   end
   let(:node_layout_view_model) { instance_double(Guide::ViewModel) }
 
@@ -48,13 +48,13 @@ RSpec.describe Guide::ScenarioLayoutView do
 
     let(:node_layout_templates) do
       {
-        'html' => 'html/layout/template',
-        'text' => 'text/layout/template',
+        html: 'html/layout/template',
+        text: 'text/layout/template',
       }
     end
 
     context 'there is a node-specific layout template for this format' do
-      let(:format_argument) { 'html' }
+      let(:format_argument) { :html }
 
       it "returns the layout template specified on the node" do
         expect(node_layout_template).to eq 'html/layout/template'
@@ -62,7 +62,7 @@ RSpec.describe Guide::ScenarioLayoutView do
     end
 
     context 'a node-specific layout template does not exist for this format' do
-      let(:format_argument) { 'pdf' }
+      let(:format_argument) { :pdf }
 
       it "returns the default layout for scenarios as specified in configuration" do
         expect(node_layout_template).to eq Guide.configuration.default_layout_for_scenarios
@@ -90,13 +90,13 @@ RSpec.describe Guide::ScenarioLayoutView do
     subject(:inject_stylesheets?) { view_model.inject_stylesheets? }
 
     context 'the scenario is in HTML format' do
-      let(:format_argument) { 'html' }
+      let(:format_argument) { :html }
 
       it { is_expected.to be true }
     end
 
     context 'the scenario is in a different format' do
-      let(:format_argument) { 'text' }
+      let(:format_argument) { :text }
 
       it { is_expected.to be false }
     end
@@ -114,13 +114,13 @@ RSpec.describe Guide::ScenarioLayoutView do
     subject(:inject_javascripts?) { view_model.inject_javascripts? }
 
     context 'the scenario is in HTML format' do
-      let(:format_argument) { 'html' }
+      let(:format_argument) { :html }
 
       it { is_expected.to be true }
     end
 
     context 'the scenario is in a different format' do
-      let(:format_argument) { 'text' }
+      let(:format_argument) { :text }
 
       it { is_expected.to be false }
     end


### PR DESCRIPTION
### Context

In #93, we added a fix so scenarios were rendered on Rails 6+. This involved converting the format from string to symbol. Unfortunately, there are a couple places in the codebase that perform comparisons on this value. Namely, the decision to include custom JS and CSS in the scenario.

### Change

Correctly inject JS and CSS into HTML scenarios by using symbols in the comparison to detect HTML.