### PR TITLE
Remove `sass-rails` dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,13 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 - Support `sprockets` version 4 ([#98]).
 
+### Removed
+
+- The `sass-rails` dependency is removed ([#99]).
+
 [Unreleased]: https://github.com/envato/guide/compare/v0.6.1...HEAD
 [#98]: https://github.com/envato/guide/pull/98
+[#99]: https://github.com/envato/guide/pull/99
 
 ## [0.6.1] - 2021-06-10
 

--- a/guide.gemspec
+++ b/guide.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |s|
   s.add_dependency "actionview", ">= 5.2"
   s.add_dependency "activemodel", ">= 5.2"
   s.add_dependency "sprockets-rails"
-  s.add_dependency "sass-rails", ">= 3.2"
 
   s.add_development_dependency "appraisal"
   s.add_development_dependency "rspec-rails"


### PR DESCRIPTION
### Context

I notice this gem doesn't have any SASS, just plain old CSS.

### Change

Remove the `sass-rails` dependency.
