### PR TITLE
Move asset compilation config to recommended location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 - Support `sprockets` version 4 ([#98]).
 
+### Changed
+
+- Moved guide asset compilation configuration to `lib/guide/engine.rb`, as
+  recommended by the [Rails Engine Guide] ([#100]).
+
 ### Removed
 
 - The `sass-rails` dependency is removed ([#99]).
@@ -21,6 +26,8 @@ The format is based on [Keep a Changelog], and this project adheres to
 [Unreleased]: https://github.com/envato/guide/compare/v0.6.1...HEAD
 [#98]: https://github.com/envato/guide/pull/98
 [#99]: https://github.com/envato/guide/pull/99
+[#100]: https://github.com/envato/guide/pull/100
+[Rails Engine Guide]: https://guides.rubyonrails.org/v6.1/engines.html#separate-assets-and-precompiling
 
 ## [0.6.1] - 2021-06-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ## [Unreleased]
 
+[Unreleased]: https://github.com/envato/guide/compare/v0.7.0...HEAD
+
+## [0.7.0] - 2021-06-11
+
 ### Added
 
 - Support `sprockets` version 4 ([#98]).
@@ -23,7 +27,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 - The `sass-rails` dependency is removed ([#99]).
 
-[Unreleased]: https://github.com/envato/guide/compare/v0.6.1...HEAD
+[0.7.0]: https://github.com/envato/guide/compare/v0.6.1...v0.7.0
 [#98]: https://github.com/envato/guide/pull/98
 [#99]: https://github.com/envato/guide/pull/99
 [#100]: https://github.com/envato/guide/pull/100

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,1 +1,0 @@
-Rails.application.config.assets.precompile += %w[guide/application.js guide/scenario.js guide/application.css]

--- a/lib/guide/engine.rb
+++ b/lib/guide/engine.rb
@@ -5,5 +5,9 @@ module Guide
     config.generators do |g|
       g.test_framework :rspec, :fixture => false
     end
+
+    initializer "guide.assets.precompile" do |app|
+      app.config.assets.precompile += %w[guide/application.js guide/scenario.js guide/application.css]
+    end
   end
 end

--- a/lib/guide/version.rb
+++ b/lib/guide/version.rb
@@ -1,3 +1,3 @@
 module Guide
-  VERSION = "0.6.1"
+  VERSION = "0.7.0"
 end


### PR DESCRIPTION
### Context

The Rails Engine Guide recommends to put asset compilation configuration in the `engine.rb` file:

```ruby
initializer "blorgh.assets.precompile" do |app|
  app.config.assets.precompile += %w( admin.js admin.css )
end

```
https://guides.rubyonrails.org/v6.1/engines.html#separate-assets-and-precompiling

### Change

- Move the asset compilation configuration.
- Prepare the release of 0.7.0